### PR TITLE
fix: Version function call is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ source "~/.zsh/spaceship-gradle/spaceship-gradle.plugin.zsh"
 
 ## Usage
 
-After installing, add the following line to your `.zshrc` in order to include Ember section in the prompt:
+After installing, add the following line to your `.zshrc` in order to include Gradle section in the prompt:
 
 ```zsh
 spaceship add gradle

--- a/spaceship-gradle.plugin.zsh
+++ b/spaceship-gradle.plugin.zsh
@@ -59,18 +59,19 @@ spaceship_gradle() {
   local gradle_version
 
   if [[ -f "$gradle_root_dir/gradlew" ]]; then
-    gradle_version=$(spaceship::gradle::versions "$gradle_root_dir/gradlew")
+    gradle_version=$(spaceship::gradle::version "$gradle_root_dir/gradlew")
   elif spaceship::exists gradle; then
-    gradle_version=$(spaceship::gradle::versions gradle)
+    gradle_version=$(spaceship::gradle::version gradle)
   else
     return
   fi
 
   [[ "$gradle_version" == "$SPACESHIP_GRADLE_DEFAULT_VERSION" ]] && return
 
-  spaceship::section::v3 \
-    "$SPACESHIP_GRADLE_COLOR" \
-    "$SPACESHIP_GRADLE_PREFIX" \
-    "$SPACESHIP_GRADLE_SYMBOL$gradle_version" \
-    "$SPACESHIP_GRADLE_SUFFIX"
+  spaceship::section \
+    --color "$SPACESHIP_GRADLE_COLOR" \
+    --prefix "$SPACESHIP_GRADLE_PREFIX" \
+    --symbol "$SPACESHIP_GRADLE_SYMBOL" \
+    --suffix "$SPACESHIP_GRADLE_SUFFIX" \
+    "${gradle_version}"
 }


### PR DESCRIPTION
#### Description
The plugin is not working since it's calling the wrong version(s) function

Plus modernize to use v4 style of section

#### Screenshot

<img width="402" alt="image" src="https://user-images.githubusercontent.com/837278/236248882-da6a1330-c63c-4ea4-9174-8ee3529f3b66.png">
